### PR TITLE
Add script for downloading Objaverse-XL objects

### DIFF
--- a/download_objects.py
+++ b/download_objects.py
@@ -1,0 +1,57 @@
+import argparse
+
+from objaverse.xl.github import GitHubDownloader
+from objaverse.xl.sketchfab import SketchfabDownloader
+from objaverse.xl.smithsonian import SmithsonianDownloader
+
+DOWNLOADERS = {
+    "github": GitHubDownloader(),
+    "sketchfab": SketchfabDownloader(),
+    "smithsonian": SmithsonianDownloader(),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download Objaverse-XL objects based on annotations"
+    )
+    parser.add_argument(
+        "--output",
+        default="~/.objaverse",
+        help="Directory to store downloaded objects",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Force redownload of annotations",
+    )
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        choices=list(DOWNLOADERS.keys()),
+        default=list(DOWNLOADERS.keys()),
+        help="Data sources to download",
+    )
+    parser.add_argument(
+        "--processes",
+        type=int,
+        default=None,
+        help="Number of parallel processes to use for downloads",
+    )
+    args = parser.parse_args()
+
+    for src in args.sources:
+        downloader = DOWNLOADERS[src]
+        annotations = downloader.get_annotations(
+            download_dir=args.output,
+            refresh=args.refresh,
+        )
+        downloader.download_objects(
+            objects=annotations,
+            download_dir=args.output,
+            processes=args.processes,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,54 @@
+import argparse
+import pandas as pd
+
+from objaverse.xl.github import GitHubDownloader
+from objaverse.xl.sketchfab import SketchfabDownloader
+from objaverse.xl.smithsonian import SmithsonianDownloader
+
+
+DOWNLOADERS = {
+    "github": GitHubDownloader(),
+    "sketchfab": SketchfabDownloader(),
+    "smithsonian": SmithsonianDownloader(),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download Objaverse-XL annotations"
+    )
+    parser.add_argument(
+        "--output",
+        default="~/.objaverse",
+        help="Directory to store annotation parquet files",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Force redownload of annotations",
+    )
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        choices=list(DOWNLOADERS.keys()),
+        default=list(DOWNLOADERS.keys()),
+        help="Data sources to download",
+    )
+    args = parser.parse_args()
+
+    frames = []
+    for src in args.sources:
+        df = DOWNLOADERS[src].get_annotations(
+            download_dir=args.output,
+            refresh=args.refresh,
+        )
+        frames.append(df)
+
+    annotations = pd.concat(frames, ignore_index=True)
+    dest = f"{args.output.rstrip('/')}/annotations.parquet"
+    annotations.to_parquet(dest)
+    print(f"Saved {len(annotations)} annotations to {dest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_objects.py` script to fetch annotations and download 3D objects from GitHub, Sketchfab, and Smithsonian sources

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'objaverse.xl.thingiverse')*

------
https://chatgpt.com/codex/tasks/task_e_68776f4d8d7c83339568c43c1b6f2071